### PR TITLE
Make sure `event.source.itemScope` is set when an item is dragged.

### DIFF
--- a/source/sortable-helper.js
+++ b/source/sortable-helper.js
@@ -226,7 +226,7 @@
             targetElementOffset: null,
             sourceInfo: {
               index: item.index(),
-              itemScope: item.itemScope,
+              itemScope: item.itemScope || item,
               sortableScope: item.sortableScope
             },
             canMove: function(itemPosition, targetElement, targetElementOffset) {


### PR DESCRIPTION
Fixing the issue with isolated scopes in 29b56a1 leads to
`item.itemScope` being undefined when executing `dragItem()`. In that
case we fallback to using simply `item` when building
`sourceInfo.itemScope`.
